### PR TITLE
Allow robo 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "require": {
         "symfony/config": "^3.0|^4.0",
-        "consolidation/robo": "^1.0"
+        "consolidation/robo": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Just tested your robo-ddev package successfully with the latest Robo version.

I only noticed that the line "Running [command]" is printed twice.
But  looking at the source code that might have already been the case with Robo 1.0.